### PR TITLE
Prevent invalid "targetIndex" reporting

### DIFF
--- a/Sources/FSPagerView.swift
+++ b/Sources/FSPagerView.swift
@@ -434,7 +434,11 @@ open class FSPagerView: UIView,UICollectionViewDataSource,UICollectionViewDelega
         if let function = self.delegate?.pagerViewWillEndDragging(_:targetIndex:) {
             let contentOffset = self.scrollDirection == .horizontal ? targetContentOffset.pointee.x : targetContentOffset.pointee.y
             let targetItem = lround(Double(contentOffset/self.collectionViewLayout.itemSpacing))
-            function(self, targetItem % self.numberOfItems)
+
+            // Prevent invalid reporting of 0 when scrolled past the last item.
+            if targetItem != self.numberOfItems {
+                function(self, targetItem % self.numberOfItems)
+            }
         }
         if self.automaticSlidingInterval > 0 {
             self.startTimer()


### PR DESCRIPTION
When scrolled past the last item, the delegate receives an invalid `targetIndex` value of `0`, even though the selected item didn't change. The delegate should not be called in such case.