### PR TITLE
Fix scroll target item calculation logic in non-infinite pager.

### DIFF
--- a/Sources/FSPagerView.swift
+++ b/Sources/FSPagerView.swift
@@ -435,16 +435,17 @@ open class FSPagerView: UIView,UICollectionViewDataSource,UICollectionViewDelega
             let contentOffset = self.scrollDirection == .horizontal ? targetContentOffset.pointee.x : targetContentOffset.pointee.y
             let targetItem = lround(Double(contentOffset/self.collectionViewLayout.itemSpacing))
 
-            // Prevent invalid reporting of 0 when scrolled past the last item.
-            if targetItem != self.numberOfItems {
+            if isInfinite {
                 function(self, targetItem % self.numberOfItems)
+            } else {
+                function(self, min(targetItem, self.numberOfItems - 1))
             }
         }
         if self.automaticSlidingInterval > 0 {
             self.startTimer()
         }
     }
-    
+
     public func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
         if let function = self.delegate?.pagerViewDidEndDecelerating {
             function(self)


### PR DESCRIPTION
Found and fixed the issue with the previous scroll target item reporting when scrolled past the last item. This fix property supports both infinite and non-infinite modes.